### PR TITLE
Added: POST /inline endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ A lightweight live parser for [Jinja2](http://jinja.pocoo.org/docs/dev/) based o
     $ pip install -r requirements.txt
     $ python parser.py config.yaml
 
+Note: if you have issues with installing the requirements related to `premailer`, please run the following command (or equivalent, depending on your system):
+
+    $ apt-get install libxml2-dev libxslt1-dev python-dev
+
 Also, you'll need to have browsersync installed. Instructions on how to install it can be found [here](http://www.browsersync.io/#install)
 
 ## Setting frontend dependencies.

--- a/parser.py
+++ b/parser.py
@@ -5,6 +5,7 @@ from random import choice
 from dronte import Objector
 import json
 import os
+import premailer
 
 
 app = Flask(__name__)
@@ -36,6 +37,12 @@ def render_post(channel, prefix, name):
         rendered_tpl = rendered_tpl.replace(' ', u'•')
 
     return Markup(rendered_tpl)
+
+
+@app.route('/inline', methods=['POST'])
+def inline_css():
+    html = request.form.get('html')
+    return premailer.transform(html)
 
 if __name__ == "__main__":
     config = Objector.from_argv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Werkzeug==0.9.6
 ipython==2.2.0
 itsdangerous==0.24
 falcon-dronte
+premailer


### PR DESCRIPTION
Now, you can make a POST request to `/inline` and pass your HTML template as text in an `html` POST parameter, and you will get as a result, your HTML template with its CSS inlined.
